### PR TITLE
(temporary patch for BM2025): OSC transmission listener, 1.1.1-TE.5a.OSC-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
 
 	<groupId>com.heronarts</groupId>
 	<artifactId>lx</artifactId>
-	<version>1.1.1-TE.5.GPU-SNAPSHOT</version>
+    <!-- temporary patch version for the OSC hook -->
+	<version>1.1.1-TE.5a.OSC-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>LX</name>

--- a/src/main/java/heronarts/lx/osc/LXOscEngine.java
+++ b/src/main/java/heronarts/lx/osc/LXOscEngine.java
@@ -73,6 +73,10 @@ public class LXOscEngine extends LXComponent {
     public void outputRemoved(LXOscEngine osc, LXOscConnection.Output output);
   }
 
+  public interface TransmissionListener {
+    public void oscMessageTransmitted(OscPacket packet);
+  }
+
   public enum IOState {
     STOPPED,
     BINDING,
@@ -162,6 +166,9 @@ public class LXOscEngine extends LXComponent {
 
   private final List<LXOscListener> listeners =
     new ArrayList<LXOscListener>();
+
+  private final List<TransmissionListener> transmissionListeners =
+    new ArrayList<TransmissionListener>();
 
   private final LXOscQueryServer oscQueryServer;
   private final Zeroconf zeroconf;
@@ -317,6 +324,27 @@ public class LXOscEngine extends LXComponent {
     return this;
   }
 
+  public LXOscEngine addTransmissionListener(TransmissionListener listener) {
+    Objects.requireNonNull("May not add null TransmissionListener");
+    if (this.transmissionListeners.contains(listener)) {
+      throw new IllegalStateException(
+        "Cannot add duplicate LXOscEngine.TransmissionListener: "
+          + listener);
+    }
+    this.transmissionListeners.add(listener);
+    return this;
+  }
+
+  public LXOscEngine removeTransmissionListener(TransmissionListener listener) {
+    if (!this.transmissionListeners.contains(listener)) {
+      throw new IllegalStateException(
+        "Cannot remove non-existent LXOscEngine.TransmissionListener: "
+          + listener);
+    }
+    this.transmissionListeners.remove(listener);
+    return this;
+  }
+
   public LXOscEngine sendMessage(String path, int value) {
     if (this.engineTransmitter != null) {
       this.engineTransmitter.sendMessage(path, value);
@@ -468,10 +496,21 @@ public class LXOscEngine extends LXComponent {
       if (this.activity != null) {
         this.activity.trigger();
       }
+      
       this.buffer.rewind();
       packet.serialize(this.buffer);
       this.packet.setLength(this.buffer.position());
       this.socket.send(this.packet);
+
+      // Notify transmission listeners
+      for (TransmissionListener listener : transmissionListeners) {
+        try {
+          listener.oscMessageTransmitted(packet);
+        } catch (Exception e) {
+          // Log error but continue with transmission
+          error(e, "Error in TransmissionListener: " + e.getMessage());
+        }
+      }
     }
 
     public void setPort(int port) {


### PR DESCRIPTION
Until we can take the time to settle on a more long-term approach to propose upstream, just including this temporary patch on our fork branch.

Corresponding TE PR stack to integrate it:
- https://github.com/titanicsend/LXStudio-TE/pull/710
- https://github.com/titanicsend/LXStudio-TE/pull/711
- https://github.com/titanicsend/LXStudio-TE/pull/712
- https://github.com/titanicsend/LXStudio-TE/pull/714